### PR TITLE
add api prefix to endpoints

### DIFF
--- a/auth/src/main/java/com/quizme/AuthController.java
+++ b/auth/src/main/java/com/quizme/AuthController.java
@@ -10,12 +10,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/api")
 public class AuthController {
 
     private final ResultToResponseEntityMapper responseMapper;

--- a/auth/src/main/java/com/quizme/security/Config.java
+++ b/auth/src/main/java/com/quizme/security/Config.java
@@ -28,10 +28,10 @@ public class Config {
                 .addFilterBefore(tokenFilter, BasicAuthenticationFilter.class)
                 .csrf(AbstractHttpConfigurer::disable) // TODO: research how to deal with csrf
                 .authorizeHttpRequests(c ->
-                        c.requestMatchers("/register").permitAll()
-                                .requestMatchers("/login/**").permitAll()
-                                .requestMatchers("/oauth2/**").permitAll()
-                                .requestMatchers("/refresh").permitAll()
+                        c.requestMatchers("/api/register").permitAll()
+                                .requestMatchers("/api/login").permitAll()
+                                .requestMatchers("/api/oauth2/**").permitAll()
+                                .requestMatchers("/api/refresh").permitAll()
                                 .requestMatchers("/error").permitAll()
                                 .requestMatchers("/actuator/health").permitAll()
                                 .anyRequest().authenticated()

--- a/auth/src/test/java/com/quizme/AuthControllerIntegrationTest.java
+++ b/auth/src/test/java/com/quizme/AuthControllerIntegrationTest.java
@@ -33,7 +33,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var requestDto = new RegisterCredentialsRequestDto("u", "e", "pw");
 
         restTestClient.post()
-                .uri("/register")
+                .uri("/api/register")
                 .body(requestDto)
                 .exchange()
                 .expectBody(User.class)
@@ -48,12 +48,12 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var requestDto = new RegisterCredentialsRequestDto("u", "e", "pw");
 
         restTestClient.post()
-                .uri("/register")
+                .uri("/api/register")
                 .body(requestDto)
                 .exchange();
 
         restTestClient.post()
-                .uri("/register")
+                .uri("/api/register")
                 .body(new RegisterCredentialsRequestDto("u2", "e", "pw2"))
                 .exchange()
                 .expectBody(ApiError.class)
@@ -61,7 +61,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
                     Assertions.assertEquals(409, error.getResponseBody().status());
                     Assertions.assertEquals("ALREADY_EXISTS", error.getResponseBody().error());
                     Assertions.assertEquals("This email is already registered", error.getResponseBody().message());
-                    Assertions.assertEquals("/register", error.getResponseBody().path());
+                    Assertions.assertEquals("/api/register", error.getResponseBody().path());
                 });
     }
 
@@ -70,12 +70,12 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var requestDto = new RegisterCredentialsRequestDto("u", "e", "pw");
 
         restTestClient.post()
-                .uri("/register")
+                .uri("/api/register")
                 .body(requestDto)
                 .exchange();
 
         restTestClient.post()
-                .uri("/register")
+                .uri("/api/register")
                 .body(new RegisterCredentialsRequestDto("u", "e2", "pw2"))
                 .exchange()
                 .expectBody(ApiError.class)
@@ -83,7 +83,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
                     Assertions.assertEquals(409, error.getResponseBody().status());
                     Assertions.assertEquals("ALREADY_EXISTS", error.getResponseBody().error());
                     Assertions.assertEquals("Username already in use", error.getResponseBody().message());
-                    Assertions.assertEquals("/register", error.getResponseBody().path());
+                    Assertions.assertEquals("/api/register", error.getResponseBody().path());
                 });
     }
 
@@ -92,7 +92,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var requestDto = new CredentialsLoginRequestDto("email", "pw");
 
         restTestClient.post()
-                .uri("/login")
+                .uri("/api/login")
                 .body(requestDto)
                 .exchange()
                 .expectBody(ApiError.class)
@@ -100,7 +100,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
                     Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), error.getResponseBody().status());
                     Assertions.assertEquals("NOT_FOUND", error.getResponseBody().error());
                     Assertions.assertEquals("Incorrect login data", error.getResponseBody().message());
-                    Assertions.assertEquals("/login", error.getResponseBody().path());
+                    Assertions.assertEquals("/api/login", error.getResponseBody().path());
                 });
     }
 
@@ -110,7 +110,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var requestDto = new CredentialsLoginRequestDto("email", "pw");
 
         restTestClient.post()
-                .uri("/login")
+                .uri("/api/login")
                 .body(requestDto)
                 .exchange()
                 .expectBody(ApiError.class)
@@ -118,7 +118,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
                     Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), error.getResponseBody().status());
                     Assertions.assertEquals("NOT_FOUND", error.getResponseBody().error());
                     Assertions.assertEquals("Incorrect login data", error.getResponseBody().message());
-                    Assertions.assertEquals("/login", error.getResponseBody().path());
+                    Assertions.assertEquals("/api/login", error.getResponseBody().path());
                 });
     }
 
@@ -128,7 +128,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var requestDto = new CredentialsLoginRequestDto("email", "pw2");
 
         restTestClient.post()
-                .uri("/login")
+                .uri("/api/login")
                 .body(requestDto)
                 .exchange()
                 .expectBody(ApiError.class)
@@ -136,7 +136,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
                     Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), error.getResponseBody().status());
                     Assertions.assertEquals("NOT_FOUND", error.getResponseBody().error());
                     Assertions.assertEquals("Incorrect login data", error.getResponseBody().message());
-                    Assertions.assertEquals("/login", error.getResponseBody().path());
+                    Assertions.assertEquals("/api/login", error.getResponseBody().path());
                 });
     }
 
@@ -146,7 +146,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var requestDto = new CredentialsLoginRequestDto("email", "pw1");
 
         restTestClient.post()
-                .uri("/login")
+                .uri("/api/login")
                 .body(requestDto)
                 .exchange()
                 .expectCookie()
@@ -177,7 +177,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
         var refreshToken = jwtUtil.generateRefreshToken("email");
 
         restTestClient.get()
-                .uri("/refresh")
+                .uri("/api/refresh")
                 .cookie("refresh_token", refreshToken)
                 .exchange()
                 .expectCookie()
@@ -214,7 +214,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
                 .compact();
 
         restTestClient.get()
-                .uri("/refresh")
+                .uri("/api/refresh")
                 .cookie("refresh_token", refreshToken)
                 .exchange()
                 .expectBody(ApiError.class)
@@ -222,7 +222,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
                     Assertions.assertEquals(new ApiError(HttpStatus.BAD_REQUEST.value(),
                             FailureReason.VALIDATION_FAILED.name(),
                             "Refresh token has expired",
-                            "/refresh"), error.getResponseBody());
+                            "/api/refresh"), error.getResponseBody());
                 });
     }
 }

--- a/auth/src/test/java/com/quizme/AuthControllerTest.java
+++ b/auth/src/test/java/com/quizme/AuthControllerTest.java
@@ -55,13 +55,13 @@ class AuthControllerTest {
         var createdUser = new User("e", "u");
         var result = Result.success(createdUser);
         when(authService.register(requestDto)).thenReturn(result);
-        when(mapper.map(result, "/register"))
+        when(mapper.map(result, "/api/register"))
                 .thenAnswer(_ ->
                         ResponseEntity.ok(createdUser)
                 );
 
         restTestClient.post()
-                .uri("/register")
+                .uri("/api/register")
                 .body(requestDto)
                 .exchange()
                 .expectBody(User.class)
@@ -78,12 +78,12 @@ class AuthControllerTest {
         when(authService.login(requestDto)).thenReturn(result);
 
         restTestClient.post()
-                .uri("/login")
+                .uri("/api/login")
                 .body(requestDto)
                 .exchange();
 
         // verify the mapper was invoked to map the response to ApiError
-        verify(mapper).map(result, "/login");
+        verify(mapper).map(result, "/api/login");
 
     }
 
@@ -96,7 +96,7 @@ class AuthControllerTest {
         when(authService.login(requestDto)).thenReturn(result);
 
         restTestClient.post()
-                .uri("/login")
+                .uri("/api/login")
                 .body(requestDto)
                 .exchange()
                 .expectCookie()
@@ -112,7 +112,7 @@ class AuthControllerTest {
         when(authService.login(requestDto)).thenReturn(result);
 
         restTestClient.post()
-                .uri("/login")
+                .uri("/api/login")
                 .body(requestDto)
                 .exchange()
                 .expectCookie()
@@ -122,21 +122,21 @@ class AuthControllerTest {
     @Test
     void refresh_returnsBadRequest_whenNullCookies() {
         restTestClient.get()
-                .uri("/refresh")
+                .uri("/api/refresh")
                 .exchange()
                 .expectBody(ApiError.class)
                 .consumeWith(error -> {
                     assertEquals(HttpStatus.BAD_REQUEST.value(), error.getResponseBody().status());
                     assertEquals(HttpStatus.BAD_REQUEST.name(), error.getResponseBody().error());
                     assertEquals("Missing refresh token cookie", error.getResponseBody().message());
-                    assertEquals("/refresh", error.getResponseBody().path());
+                    assertEquals("/api/refresh", error.getResponseBody().path());
                 });
     }
 
     @Test
     void refresh_returnsBadRequest_whenRefreshTokenCookieNotFound() {
         restTestClient.get()
-                .uri("/refresh")
+                .uri("/api/refresh")
                 .cookie("someOtherCookie", "abc")
                 .exchange()
                 .expectBody(ApiError.class)
@@ -144,7 +144,7 @@ class AuthControllerTest {
                     assertEquals(HttpStatus.BAD_REQUEST.value(), error.getResponseBody().status());
                     assertEquals(HttpStatus.BAD_REQUEST.name(), error.getResponseBody().error());
                     assertEquals("Missing refresh token cookie", error.getResponseBody().message());
-                    assertEquals("/refresh", error.getResponseBody().path());
+                    assertEquals("/api/refresh", error.getResponseBody().path());
                 });
     }
 
@@ -155,11 +155,11 @@ class AuthControllerTest {
         when(userService.refreshToken(any())).thenReturn(result);
 
         restTestClient.get()
-                .uri("/refresh")
+                .uri("/api/refresh")
                 .cookie(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, "xyz")
                 .exchange();
 
-        verify(mapper).map(result, "/refresh");
+        verify(mapper).map(result, "/api/refresh");
     }
 
     @Test
@@ -173,7 +173,7 @@ class AuthControllerTest {
         when(userService.refreshToken(any())).thenReturn(result);
 
         restTestClient.get()
-                .uri("/refresh")
+                .uri("/api/refresh")
                 .exchange()
                 .expectCookie()
                 .valueEquals(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, "refresh");
@@ -190,7 +190,7 @@ class AuthControllerTest {
         when(userService.refreshToken(any())).thenReturn(result);
 
         restTestClient.get()
-                .uri("/refresh")
+                .uri("/api/refresh")
                 .exchange()
                 .expectCookie()
                 .valueEquals(CookieUtil.ACCESS_TOKEN_COOKIE_NAME, "access");

--- a/business/src/main/java/com/quizme/controllers/CategoryController.java
+++ b/business/src/main/java/com/quizme/controllers/CategoryController.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/categories")
+@RequestMapping("/api/categories")
 public class CategoryController {
 
     private final ResultToResponseEntityMapper responseMapper;

--- a/business/src/main/java/com/quizme/controllers/QuestionController.java
+++ b/business/src/main/java/com/quizme/controllers/QuestionController.java
@@ -12,7 +12,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/questions")
+@RequestMapping("/api/questions")
 public class QuestionController {
 
     private final ResultToResponseEntityMapper responseMapper;

--- a/business/src/main/java/com/quizme/controllers/QuizController.java
+++ b/business/src/main/java/com/quizme/controllers/QuizController.java
@@ -13,7 +13,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/quiz")
+@RequestMapping("/api/quiz")
 public class QuizController {
 
     private final UserRepo userRepo;

--- a/business/src/test/java/com/quizme/controllers/CategoryControllerIntegrationTest.java
+++ b/business/src/test/java/com/quizme/controllers/CategoryControllerIntegrationTest.java
@@ -33,7 +33,7 @@ class CategoryControllerIntegrationTest extends IntegrationTest {
         var requestDto = new NewCategoryDto("new");
 
         restTestClient.post()
-                .uri("/categories")
+                .uri("/api/categories")
                 .header("Idempotency-Key", "some-key")
                 .body(requestDto)
                 .cookie("access_token", accessToken)
@@ -52,7 +52,7 @@ class CategoryControllerIntegrationTest extends IntegrationTest {
         categoryService.createCategory(requestDto, user, "k45t");
 
         restTestClient.post()
-                .uri("/categories")
+                .uri("/api/categories")
                 .body(requestDto)
                 .header("Idempotency-Key", "some-key2")
                 .cookie("access_token", accessToken)
@@ -62,7 +62,7 @@ class CategoryControllerIntegrationTest extends IntegrationTest {
                     assertEquals(409, error.getResponseBody().status());
                     assertEquals("ALREADY_EXISTS", error.getResponseBody().error());
                     assertEquals("Category with same name already exists", error.getResponseBody().message());
-                    assertEquals("/categories", error.getResponseBody().path());
+                    assertEquals("/api/categories", error.getResponseBody().path());
                 });
     }
 
@@ -76,7 +76,7 @@ class CategoryControllerIntegrationTest extends IntegrationTest {
         categoryService.createCategory(requestDto3, user, "k2");
 
         restTestClient.get()
-                .uri("/categories")
+                .uri("/api/categories")
                 .cookie("access_token", accessToken)
                 .exchange()
                 .expectBody(new ParameterizedTypeReference<List<CreatedCategoryDto>>() {

--- a/business/src/test/java/com/quizme/controllers/CategoryControllerTest.java
+++ b/business/src/test/java/com/quizme/controllers/CategoryControllerTest.java
@@ -53,7 +53,7 @@ class CategoryControllerTest {
         when(userRepo.findByEmail(any())).thenReturn(Optional.of(mock(User.class)));
 
         restTestClient.post()
-                .uri("/categories")
+                .uri("/api/categories")
                 .body(new NewCategoryDto("exists"))
                 .exchange()
                 .expectBody(CreatedCategoryDto.class)
@@ -71,12 +71,12 @@ class CategoryControllerTest {
         when(userRepo.findByEmail(any())).thenReturn(Optional.of(mock(User.class)));
 
         restTestClient.post()
-                .uri("/categories")
+                .uri("/api/categories")
                 .body(new NewCategoryDto("exists"))
                 .exchange();
 
         // verify the mapper was invoked to map the response to ApiError
-        verify(mapper).map(result, "/categories");
+        verify(mapper).map(result, "/api/categories");
     }
 
     @Test
@@ -88,7 +88,7 @@ class CategoryControllerTest {
         when(userRepo.findByEmail(any())).thenReturn(Optional.of(mock(User.class)));
 
         restTestClient.get()
-                .uri("/categories")
+                .uri("/api/categories")
                 .exchange()
                 .expectBody(new ParameterizedTypeReference<List<CreatedCategoryDto>>() {
                 })

--- a/business/src/test/java/com/quizme/controllers/QuestionControllerIntegrationTest.java
+++ b/business/src/test/java/com/quizme/controllers/QuestionControllerIntegrationTest.java
@@ -42,7 +42,7 @@ class QuestionControllerIntegrationTest extends IntegrationTest {
         var requestDto = new NewQuestionDto("newQ", Set.of(choice), Set.of(1L));
 
         restTestClient.post()
-                .uri("/questions")
+                .uri("/api/questions")
                 .body(requestDto)
                 .cookie("access_token", accessToken)
                 .header("Idempotency-Key", "idk1")
@@ -65,7 +65,7 @@ class QuestionControllerIntegrationTest extends IntegrationTest {
         questionService.createQuestion(new NewQuestionDto("duplicate question", Set.of(choice), Set.of(1L)), user, "k2");
 
         restTestClient.post()
-                .uri("/questions")
+                .uri("/api/questions")
                 .body(new NewQuestionDto("Duplicate Question", Set.of(choice), Set.of(1L)))
                 .cookie("access_token", accessToken)
                 .header("Idempotency-Key", "idk1")
@@ -75,14 +75,14 @@ class QuestionControllerIntegrationTest extends IntegrationTest {
                     assertEquals(409, error.getResponseBody().status());
                     assertEquals("ALREADY_EXISTS", error.getResponseBody().error());
                     assertEquals("Question already exists", error.getResponseBody().message());
-                    assertEquals("/questions", error.getResponseBody().path());
+                    assertEquals("/api/questions", error.getResponseBody().path());
                 });
     }
 
     @Test
     void createQuestion_returnsHttp409_whenNoCategoryProvided() {
         restTestClient.post()
-                .uri("/questions")
+                .uri("/api/questions")
                 .body(new NewQuestionDto("Question", Set.of(choice), Set.of()))
                 .cookie("access_token", accessToken)
                 .header("Idempotency-Key", "idk1")
@@ -92,7 +92,7 @@ class QuestionControllerIntegrationTest extends IntegrationTest {
                     assertEquals(400, error.getResponseBody().status());
                     assertEquals("VALIDATION_FAILED", error.getResponseBody().error());
                     assertEquals("Question must belong to at least one category", error.getResponseBody().message());
-                    assertEquals("/questions", error.getResponseBody().path());
+                    assertEquals("/api/questions", error.getResponseBody().path());
                 });
     }
 
@@ -103,7 +103,7 @@ class QuestionControllerIntegrationTest extends IntegrationTest {
         var requestDto = new NewQuestionDto("newQ", Set.of(choice), Set.of(1L, 2L, 3L)); // 3 doesn't exist
 
         restTestClient.post()
-                .uri("/questions")
+                .uri("/api/questions")
                 .body(requestDto)
                 .cookie("access_token", accessToken)
                 .header("Idempotency-Key", "idk1")
@@ -128,7 +128,7 @@ class QuestionControllerIntegrationTest extends IntegrationTest {
         var requestDto = new NewQuestionDto("newQ", Set.of(choice), Set.of(1L, 2L));
 
         restTestClient.post()
-                .uri("/questions")
+                .uri("/api/questions")
                 .body(requestDto)
                 .cookie("access_token", accessToken)
                 .header("Idempotency-Key", "idk1")

--- a/business/src/test/java/com/quizme/controllers/QuestionControllerTest.java
+++ b/business/src/test/java/com/quizme/controllers/QuestionControllerTest.java
@@ -56,7 +56,7 @@ class QuestionControllerTest {
         when(userRepo.findByEmail(any())).thenReturn(Optional.of(mock(User.class)));
 
         restTestClient.post()
-                .uri("/questions")
+                .uri("/api/questions")
                 .body(new NewQuestionDto("", Set.of(), Set.of()))
                 .exchange()
                 .expectBody(QuestionDto.class)
@@ -76,12 +76,12 @@ class QuestionControllerTest {
         when(userRepo.findByEmail(any())).thenReturn(Optional.of(mock(User.class)));
 
         restTestClient.post()
-                .uri("/questions")
+                .uri("/api/questions")
                 .body(new NewQuestionDto("", Set.of(), Set.of()))
                 .exchange();
 
         // verify the mapper was invoked to map the response to ApiError
-        verify(mapper).map(result, "/questions");
+        verify(mapper).map(result, "/api/questions");
     }
 
 }

--- a/business/src/test/java/com/quizme/controllers/QuizControllerIntegrationTest.java
+++ b/business/src/test/java/com/quizme/controllers/QuizControllerIntegrationTest.java
@@ -66,7 +66,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
         var requestDto = new NewQuizDto(2, QuestionsPicker.Strategy.RANDOM);
 
         restTestClient.post()
-                .uri("/quiz/new")
+                .uri("/api/quiz/new")
                 .body(requestDto)
                 .cookie("access_token", accessToken)
                 .header("Idempotency-Key", "idk1")
@@ -97,7 +97,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
         var requestDto = new NewQuizDto(3, QuestionsPicker.Strategy.RANDOM);
 
         restTestClient.post()
-                .uri("/quiz/new")
+                .uri("/api/quiz/new")
                 .header("Idempotency-Key", "idk1")
                 .body(requestDto)
                 .cookie("access_token", accessToken)
@@ -120,7 +120,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
         var requestDto = new NewQuizDto(3, QuestionsPicker.Strategy.RANDOM);
 
         restTestClient.post()
-                .uri("/quiz/new")
+                .uri("/api/quiz/new")
                 .body(requestDto)
                 .cookie("access_token", accessToken)
                 .header("Idempotency-Key", "idk1")
@@ -131,7 +131,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
                     assertEquals("VALIDATION_FAILED", error.getResponseBody().error());
                     assertEquals("Requested quiz to contain 3 questions, " +
                             "but user has 1 applicable questions only", error.getResponseBody().message());
-                    assertEquals("/quiz/new", error.getResponseBody().path());
+                    assertEquals("/api/quiz/new", error.getResponseBody().path());
                 });
     }
 
@@ -160,7 +160,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
         var submitQuizDto = new SubmittedQuizDto(quizDto.id(), List.of(attempt1, attempt2, attempt3));
 
         restTestClient.post()
-                .uri("/quiz/submit")
+                .uri("/api/quiz/submit")
                 .body(submitQuizDto)
                 .cookie("access_token", accessToken)
                 .exchange()
@@ -195,7 +195,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
     @Test
     void submitQuiz_RETURNS_404_WHEN_QuizNotFound() {
         restTestClient.post()
-                .uri("/quiz/submit")
+                .uri("/api/quiz/submit")
                 .body(new SubmittedQuizDto(1, List.of()))
                 .cookie("access_token", accessToken)
                 .exchange()
@@ -206,7 +206,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
                     assertEquals(404, error.getResponseBody().status());
                     assertEquals("NOT_FOUND", error.getResponseBody().error());
                     assertEquals("Quiz not found", error.getResponseBody().message());
-                    assertEquals("/quiz/submit", error.getResponseBody().path());
+                    assertEquals("/api/quiz/submit", error.getResponseBody().path());
                 });
     }
 
@@ -233,7 +233,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
         var submitQuizDto = new SubmittedQuizDto(quizDto.id(), List.of(attempt1, attempt2));
 
         restTestClient.post()
-                .uri("/quiz/submit")
+                .uri("/api/quiz/submit")
                 .body(submitQuizDto)
                 .cookie("access_token", accessToken)
                 .exchange()
@@ -244,7 +244,7 @@ class QuizControllerIntegrationTest extends IntegrationTest {
                     assertEquals(400, error.getResponseBody().status());
                     assertEquals("VALIDATION_FAILED", error.getResponseBody().error());
                     assertEquals("Found question with multiple answers", error.getResponseBody().message());
-                    assertEquals("/quiz/submit", error.getResponseBody().path());
+                    assertEquals("/api/quiz/submit", error.getResponseBody().path());
                 });
     }
 

--- a/business/src/test/java/com/quizme/controllers/QuizControllerTest.java
+++ b/business/src/test/java/com/quizme/controllers/QuizControllerTest.java
@@ -67,7 +67,7 @@ class QuizControllerTest {
         when(userRepo.findByEmail(any())).thenReturn(Optional.of(user));
 
         restTestClient.post()
-                .uri("/quiz/new")
+                .uri("/api/quiz/new")
                 .body(new NewQuizDto(4, QuestionsPicker.Strategy.RANDOM))
                 .exchange()
                 .expectBody(QuizDto.class)
@@ -91,12 +91,12 @@ class QuizControllerTest {
         when(userRepo.findByEmail(any())).thenReturn(Optional.of(mock(User.class)));
 
         restTestClient.post()
-                .uri("/quiz/new")
+                .uri("/api/quiz/new")
                 .body(new NewQuizDto(3, QuestionsPicker.Strategy.RANDOM))
                 .exchange();
 
         // verify the mapper was invoked to map the response to ApiError
-        verify(mapper).map(result, "/quiz/new");
+        verify(mapper).map(result, "/api/quiz/new");
     }
 
     @Test
@@ -105,7 +105,7 @@ class QuizControllerTest {
         when(quizService.submitQuiz(any())).thenReturn(result);
 
         restTestClient.post()
-                .uri("/quiz/submit")
+                .uri("/api/quiz/submit")
                 .body(new SubmittedQuizDto(1, List.of()))
                 .exchange()
                 .expectStatus()
@@ -119,19 +119,19 @@ class QuizControllerTest {
         when(quizService.submitQuiz(any())).thenReturn(result);
 
         restTestClient.post()
-                .uri("/quiz/submit")
+                .uri("/api/quiz/submit")
                 .body(new SubmittedQuizDto(1, List.of()))
                 .exchange();
 
         // verify the mapper was invoked to map the response to ApiError
-        verify(mapper).map(result, "/quiz/submit");
+        verify(mapper).map(result, "/api/quiz/submit");
     }
 
     @ParameterizedTest
     @MethodSource("invalidQuestionsCount")
     void createQuiz_RETURNS_400_WHEN_nonPositiveQuestionsCount(int count) {
         restTestClient.post()
-                .uri("/quiz/new")
+                .uri("/api/quiz/new")
                 .body(new NewQuizDto(count, QuestionsPicker.Strategy.RANDOM))
                 .exchange()
                 .expectBody(ApiError.class)
@@ -139,7 +139,7 @@ class QuizControllerTest {
                     assertEquals(HttpStatus.BAD_REQUEST.value(), error.getResponseBody().status());
                     assertEquals(FailureReason.VALIDATION_FAILED.name(), error.getResponseBody().error());
                     assertEquals("Invalid request parameters: Quiz must have at least one question", error.getResponseBody().message());
-                    assertEquals("/quiz/new", error.getResponseBody().path());
+                    assertEquals("/api/quiz/new", error.getResponseBody().path());
                 });
     }
 }

--- a/docker-volume/grafana/dashboards/metrics-dashboard.json
+++ b/docker-volume/grafana/dashboards/metrics-dashboard.json
@@ -5,8 +5,8 @@
     "name": "54cf8823-3929-4281-8ea8-ba87dd605cdc",
     "namespace": "default",
     "uid": "17555281-f595-4b44-b7c4-09a83aafc0df",
-    "resourceVersion": "1783780149682013",
-    "generation": 8,
+    "resourceVersion": "1783780403585001",
+    "generation": 9,
     "creationTimestamp": "2026-07-08T17:54:18Z",
     "labels": {
       "grafana.app/deprecatedInternalID": "3259163168976896"
@@ -16,11 +16,11 @@
       "grafana.app/folder": "bfrifz7vc7ldsa",
       "grafana.app/managedBy": "classic-file-provisioning",
       "grafana.app/managerId": "QuizMe",
-      "grafana.app/sourceChecksum": "12e09fa1cafb25386544da2d1da0969a",
+      "grafana.app/sourceChecksum": "f9bd98531b1b529e1fb1ed209662f657",
       "grafana.app/sourcePath": "/etc/grafana/provisioning/dashboards/metrics-dashboard.json",
-      "grafana.app/sourceTimestamp": "1783780124000",
+      "grafana.app/sourceTimestamp": "1783780369000",
       "grafana.app/updatedBy": "access-policy:service",
-      "grafana.app/updatedTimestamp": "2026-07-11T14:29:09Z",
+      "grafana.app/updatedTimestamp": "2026-07-11T14:33:23Z",
       "grafana.app/folderTitle": "QuizMe",
       "grafana.app/folderUrl": "/dashboards/f/bfrifz7vc7ldsa/quizme"
     }
@@ -153,7 +153,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(http_server_requests_milliseconds_count {status=~\"5..\", exported_job=\"${exported_job}\"}[$__range]))",
+                        "expr": "sum(rate(http_server_requests_milliseconds_count {status=~\"5..\", uri=~\"/api.*\",exported_job=\"${exported_job}\"}[$__range]))",
                         "instant": false,
                         "legendFormat": "__auto",
                         "range": true
@@ -238,7 +238,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(increase(http_server_requests_milliseconds_count{status=~\"2..\", uri!=\"/actuator/health\", exported_job=\"${exported_job}\"}[$__range]))",
+                        "expr": "sum(increase(http_server_requests_milliseconds_count{status=~\"2..\", uri=~\"/api.*\", exported_job=\"${exported_job}\"}[$__range]))",
                         "instant": true,
                         "legendFormat": "__auto",
                         "range": false
@@ -321,7 +321,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(increase(http_server_requests_milliseconds_count{status!~\"2..\", exported_job=\"${exported_job}\"}[$__range]))",
+                        "expr": "sum(increase(http_server_requests_milliseconds_count{status!~\"2..\",uri=~\"/api.*\", exported_job=\"${exported_job}\"}[$__range]))",
                         "instant": true,
                         "legendFormat": "__auto",
                         "range": false
@@ -769,7 +769,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(increase(http_server_requests_milliseconds_count{uri!=\"/actuator/health\", exported_job=\"${exported_job}\"}[$__range]))",
+                        "expr": "sum(increase(http_server_requests_milliseconds_count{uri=~\"/api.*\", exported_job=\"${exported_job}\"}[$__range]))",
                         "instant": true,
                         "legendFormat": "__auto",
                         "range": false
@@ -851,7 +851,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(http_server_requests_milliseconds_count{status=~\"2..\", exported_job=\"${exported_job}\"}[$__range]))/sum(increase(http_server_requests_milliseconds_count{exported_job=\"${exported_job}\"}[$__range]))*100",
+                        "expr": "sum(increase(http_server_requests_milliseconds_count{status=~\"2..\", uri=~\"/api.*\",exported_job=\"${exported_job}\"}[$__range]))/sum(increase(http_server_requests_milliseconds_count{uri=~\"/api.*\",exported_job=\"${exported_job}\"}[$__range]))*100",
                         "instant": false,
                         "legendFormat": "__auto",
                         "range": true
@@ -953,7 +953,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(http_server_requests_milliseconds_count {status=~\"4..\", exported_job=\"${exported_job}\"}[$__range]))",
+                        "expr": "sum(rate(http_server_requests_milliseconds_count {status=~\"4..\", uri=~\"/api.*\",exported_job=\"${exported_job}\"}[$__range]))",
                         "instant": false,
                         "legendFormat": "__auto",
                         "range": true
@@ -1036,7 +1036,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(http_server_requests_milliseconds_count {status=~\"2..\", exported_job=\"${exported_job}\"}[$__range]))",
+                        "expr": "sum(rate(http_server_requests_milliseconds_count {status=~\"2..\",uri=~\"/api.*\", exported_job=\"${exported_job}\"}[$__range]))",
                         "instant": false,
                         "legendFormat": "__auto",
                         "range": true

--- a/docker-volume/grafana/dashboards/traces-dashboard.json
+++ b/docker-volume/grafana/dashboards/traces-dashboard.json
@@ -5,8 +5,8 @@
     "name": "8ef2a47a-7554-4e15-ad02-a93df59815af",
     "namespace": "default",
     "uid": "e1b23827-3b0a-4d52-a350-c07729a63c38",
-    "resourceVersion": "1783761814021982",
-    "generation": 1,
+    "resourceVersion": "1783762121585995",
+    "generation": 2,
     "creationTimestamp": "2026-07-11T09:23:34Z",
     "labels": {
       "grafana.app/deprecatedInternalID": "4217793401806848"
@@ -16,9 +16,11 @@
       "grafana.app/folder": "bfrifz7vc7ldsa",
       "grafana.app/managedBy": "classic-file-provisioning",
       "grafana.app/managerId": "QuizMe",
-      "grafana.app/sourceChecksum": "0cf03d0dcd3ace7ab397b7465979a36d",
+      "grafana.app/sourceChecksum": "aa0acaaee23c63a6be32013421b6405a",
       "grafana.app/sourcePath": "/etc/grafana/provisioning/dashboards/traces-dashboard.json",
-      "grafana.app/sourceTimestamp": "1764406171000",
+      "grafana.app/sourceTimestamp": "1783762050000",
+      "grafana.app/updatedBy": "access-policy:service",
+      "grafana.app/updatedTimestamp": "2026-07-11T09:28:41Z",
       "grafana.app/folderTitle": "QuizMe",
       "grafana.app/folderUrl": "/dashboards/f/bfrifz7vc7ldsa/quizme"
     }
@@ -86,11 +88,12 @@
                             "valueType": "keyword"
                           }
                         ],
-                        "limit": 20,
+                        "limit": 2000,
                         "metricsQueryType": "range",
-                        "query": "{trace:rootName != \"http get /actuator/health\" && trace:rootName != \"info\"}",
+                        "query": "{trace:rootName =~ \".*/api/.*\"}",
                         "queryType": "traceql",
                         "serviceMapUseNativeHistograms": false,
+                        "spss": 100,
                         "tableType": "traces"
                       },
                       "version": "v0"

--- a/gateway/src/main/java/com/quizme/auth/SecurityConfig.java
+++ b/gateway/src/main/java/com/quizme/auth/SecurityConfig.java
@@ -25,10 +25,10 @@ public class SecurityConfig {
                 .addFilterBefore(tokenFilter, BasicAuthenticationFilter.class)
                 .csrf(AbstractHttpConfigurer::disable) // TODO: research how to deal with csrf
                 .authorizeHttpRequests(c ->
-                        c.requestMatchers("/register").permitAll()
-                                .requestMatchers("/login/**").permitAll()
-                                .requestMatchers("/oauth2/**").permitAll()
-                                .requestMatchers("/refresh").permitAll()
+                        c.requestMatchers("/api/register").permitAll()
+                                .requestMatchers("/api/login").permitAll()
+                                .requestMatchers("/api/oauth2/**").permitAll()
+                                .requestMatchers("/api/refresh").permitAll()
                                 .requestMatchers("/error").permitAll()
                                 .requestMatchers("/actuator/health").permitAll()
                                 .anyRequest().authenticated()


### PR DESCRIPTION
- add /api prefix to endpoints
- update traces and metrics dashboards to rely on /api prefix when filtering uri.